### PR TITLE
Make abstract

### DIFF
--- a/.github/run-shim.el
+++ b/.github/run-shim.el
@@ -77,7 +77,7 @@
           '(;; "--no-<check>
             ;; "--no-byte-compile"
             ;; "--no-checkdoc"
-            ;; "--no-package-lint"
+            "--no-package-lint"
             "--no-indent"
             ;; "--no-indent-character"
             ;; "--no-fill-column"

--- a/lisp/user-keys-abstract.el
+++ b/lisp/user-keys-abstract.el
@@ -1,0 +1,246 @@
+;;; user-keys-abstract.el --- Make binding conventions configurable -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022 Positron Solutions
+
+;; Author: Psionik K <73710933+psionic-k@users.noreply.github.com>
+;; Keywords: convenience
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Homepage: http://github.com/positron-solutions/user-keys-abstract
+
+;;; License notice:
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This module is a proof of concept for properly implementing conventions such
+;; as C-n and C-p for list and line navigation.  Because lists are the most
+;; prevalent concept in Lisp, and Emacs Lisp, the keys for navigating lists are
+;; among the first that the user should have a choice in rebinding.
+
+;;; Code:
+
+(require 'dash)
+
+(defun user-keys-abstract--strip-kwargs (form)
+  "Return the stripped FORM and keyword-args as a plist.
+FORM must be a list.  Keyword args can be out of order but each
+value is assumed to follow the keyword."
+  (let* ((kwargs)
+         (key)
+         (stripped))
+    (--each form
+      (if key (progn
+                (push it kwargs)
+                (push key kwargs)
+                (setq key nil))
+        (if (and (symbolp it)
+                 ;; look for colon at beginning of symbol name
+                 (equal ?\: (aref (symbol-name it) 0)))
+            (setq key it)
+          (push it stripped))))
+    (list (reverse stripped) kwargs)))
+
+(defun user-keys-abstract--expand-shadow-remaps (form)
+  "Expand the shadow-remaps contained in FORM and flatten.
+FORM is a `(remap-definition shadow-remap ... shadow-remap)'
+declaration accepted by `user-keys-abstract-define-remap'."
+
+  (pcase-let* ((`(,remap-def _)
+                (user-keys-abstract--strip-kwargs (car form)))
+               (`(,abstract-command-name ,orig-sequence _)
+                remap-def))
+    (let* ((shadow-remaps (cdr form))
+           ;; push feature to each shadow-remap and normalize each output to
+           ;; `((feature shadow-remap) (feature shadow-remap))'
+           (shadow-remaps
+            (-reduce #'append
+                     (--map (let ((feature (car it))
+                                  (remaps (cdr it)))
+                              (--map (cons feature it)
+                                     (if (listp (car remaps))
+                                         remaps
+                                       (list remaps))))
+                            shadow-remaps))))
+      (->> shadow-remaps
+           (-map
+            (lambda (shadow-remap)
+              (pcase-let ((`(,feature ,map ,shadow-command) shadow-remap))
+                (list
+                 ;; unbind the existing sequence
+                 (if (version< "29" emacs-version)
+                     `(,feature (define-key ,map (kbd ,orig-sequence) nil t))
+                   ;; emacs 28 cannot remove bindings entirely
+                   `(,feature (define-key ,map (kbd ,orig-sequence) nil)))
+                 ;; remap-bind to the abstract command
+                 `(,feature (define-key
+                             ,map
+                             (vector 'remap #',abstract-command-name)
+                             #',shadow-command))))))
+           ;; flatten each pair of `define-key' expressions
+           (-reduce #'append)))))
+
+(defmacro user-keys-abstract-define-remap (&rest forms)
+  "Re-map multiple bindings onto new abstract commands.
+An abstract command is one that is usually bound to a sequence.
+Real commands that would normally shadow the sequence directly
+are instead bound via command remapping.  Thus, if the abstract
+command is rebound to another sequence, all of the shadows move
+with it.  This converts ad-hoc sequence conventions like `C-n'
+into first-class conventions that the user can manage more
+effectively.
+
+To illustrate, after abstracting all of the `C-n' commands to an
+abstract command such as `user-keys-abstract-next', you can
+rebind `user-keys-abstract-next' to `C-j' and all of the remapped
+commands will move with it, meaning commands like `next-line'
+move to `C-j' as well.  You can even remove these keys by
+providing no binding to the abstract command.
+
+Regarding the implementation and usage, at a high level, this
+macro returns expressions that define abstract commands, binds
+them to a sequence, and then uses command remapping to re-direct
+the abstract command to a concrete command in a number of
+keymaps.  Because these are lazily loaded, `eval-after-load' is
+used and we need to know the feature name or elisp file.  When
+making sequences abstract, the sequence binding in each map is
+removed so that the map only contains the command remap.  This
+enables rebinding of the abstract command's sequence to affect
+all abstracted sequences.
+
+Each form in FORMS has the following structure:
+
+`(remap-definition shadow-remap ... shadow-remap)'
+
+Each REMAP-DEFINITION form is the following:
+
+`(abstract-command-name sequence-string original-command &rest args)'
+
+ARGS should be plist style pairs of :keyword value, with the following support:
+
+- :map for any map other than the `global-map'.
+- :target-sequence if you want to bind commands to a new sequence other than
+  SEQUENCE-STRING.  This is used to both define the abstract command and place
+  it on a different binding.
+- :no-bind if you want to define the abstract command but not the key sequence.
+  Without a key sequence, any REMAP-DEFINITION forms using the abstract command
+  will not have an active binding, just a remap to a command that is not itself
+  bound.
+
+Each SHADOW-REMAP form is one of the following:
+
+`(feature1 map shadow-command)'
+`(feature2 (map1 shadow-command)
+           (map2 shadow-command))'
+
+FEATURE can be any expression suitable for `eval-after-load' and
+usually you will use a feature symbol, unquoted, or a string that
+points to a file.  In the case of subr.el, where many of the most
+fundamental maps are defined, there is no corresponding feature,
+so just use the elisp file name.
+
+SHADOW-COMMAND is the command that shadows the SEQUENCE-STRING in
+the REMAP-DEFINITION.  Two expressions will be generated.  One to
+unbind SHADOW-COMMAND from SEQUENCE-STRING and another to remap
+ABSTRACT-COMMAND-NAME to SHADOW-COMMAND so that SHADOW-COMMAND is
+active whenever that map has precedence.
+
+TODO shadow-remap forms need plist support.  If the command is
+being moved from a sequence other than SEQUENCE-STRING, this
+needs to be expressed per shadow-command.
+
+TODO When a :target-sequence is expressed, it may need unbinding
+in many, many maps so that the abstract command is not shadowed
+after being moved.  At a minimum, unbind in maps with remaps.
+
+TODO Moving sequences needs to be coordinated over all forms so
+that unbinding and rebinding don't clobber each other in the
+global map."
+
+  (let* ((remap-defs (-map #'car forms))
+         ;; define abstract commands for each remap-def
+         (ac-def-forms
+          (->> remap-defs
+               (-map #'car)
+               (-map (lambda (abstract-command-name)
+                       `(defun ,abstract-command-name '()
+                          ,(concat "Abstract command target.\n"
+                                   "This is a global map abstract command.")
+                          (interactive)
+                          (undefined))))))
+         ;; define global map binding & remap for each remap-def
+         (global-remap-forms
+          (->> remap-defs
+               (-map
+                (lambda (remap-def)
+                  (pcase-let* ((`(,remap-def ,remap-kwargs)
+                                (user-keys-abstract--strip-kwargs remap-def))
+                               (`(,abstract-command-name
+                                  ,sequence-string
+                                  ,original-command)
+                                remap-def))
+                    (let ((no-bind (plist-get remap-kwargs :no-bind))
+                          (target-sequence
+                           (plist-get remap-kwargs :target-sequence)))
+                      (list
+                       ;; unbind the original command from the original sequence
+                       (when target-sequence
+                         (if (version< "29" emacs-version)
+                             `(define-key global-map (kbd ,sequence-string) nil t)
+                           ;; emacs 28 cannot remove bindings entirely
+                           `(define-key global-map (kbd ,sequence-string) nil)))
+
+                       ;; bind the abstract command to the target sequence
+                       (unless no-bind
+                         `(define-key
+                           global-map
+                           (kbd ,(or target-sequence sequence-string))
+                           #',abstract-command-name))
+
+                       ;; remap the original command to the abstract command
+                       `(define-key
+                         global-map
+                         (vector 'remap #',abstract-command-name)
+                         #',original-command))))))
+
+                (-reduce #'append)
+                (-non-nil)))
+
+         ;; for each remap-def, expand its shadow-remap forms over their feature,
+         ;; then gather all shadow-remaps over features and generate
+         ;; `eval-after-load' expressions.
+         (eval-after-load-forms
+          (->>
+           forms
+           ;; expand shadow-remap forms over the remap-definition
+           (-map #'user-keys-abstract--expand-shadow-remaps)
+           (-reduce #'append)          ; flatten over each remap-def
+           (-group-by #'car)            ; group shadow-remaps by feature
+           (-map
+            (lambda (feature-group)
+              ;; feature-group is (feature ((feature rebind) (feature rebind)))
+              ;; with all same feature
+              (let ((feature (car feature-group))
+                    (shadow-remaps (-map #'cadr (cdr feature-group))))
+                `(eval-after-load ,feature ,@shadow-remaps)))))))
+    ;; splice
+    `(progn ,@ac-def-forms
+            ,@global-remap-forms
+            ,@eval-after-load-forms)))
+
+(provide 'user-keys-abstract)
+;;; user-keys-abstract.el ends here

--- a/lisp/user-keys-abstract.el
+++ b/lisp/user-keys-abstract.el
@@ -236,11 +236,61 @@ global map."
               ;; with all same feature
               (let ((feature (car feature-group))
                     (shadow-remaps (-map #'cadr (cdr feature-group))))
-                `(eval-after-load ,feature ,@shadow-remaps)))))))
+                `(eval-after-load ',feature (progn ,@shadow-remaps))))))))
     ;; splice
     `(progn ,@ac-def-forms
             ,@global-remap-forms
             ,@eval-after-load-forms)))
+
+(defun user-keys-abstract-list-navigation ()
+  "WARNING!  YOU BETTER KNOW WHAT YOU ARE DOING!
+Okay, so you found this pre-alpha backage and it says it can make
+your bindings abstract, allowing you to move around `C-n' and
+`C-p' etc.  This function will do it, but it's basically a demo
+and not intended to be run in your daily driving.  This is why I
+did not bind it in a command."
+  (user-keys-abstract-define-remap
+       ((abstract-next "C-n" next-line)
+        ("subr.el" esc-map backward-list)
+        (calendar-mode calendar-mode-map calendar-backward-week)
+        (comint-mode comint-repeat-map comint-previous-prompt)
+        (company-mode (company-active-map company-select-previous-or-abort)
+                      (company-search-map company-select-previous-or-abort))
+        ;; (doc-view doc-view-mode-map doc-view-previous-line-or-previous-page)
+        (gnus gnus-summary-goto-map gnus-summary-prev-same-subject)
+        (kmacro kmacro-keymap kmacro-cycle-ring-previous)
+        (org (org-agenda-keymap org-agenda-previous-line)
+             (org-agenda-mode-map org-agenda-previous-line)
+             (org-babel-map org-babel-previous-src-block))
+        (outline (outline-mode-prefix-map outline-previous-visible-heading)
+                 (outline-navigation-repeat-map outline-previous-visible-heading))
+        (popup popup-menu-keymap popup-previous)
+        (quail quail-simple-translation-keymap quail-other-command)
+        (quail quail-translation-keymap quail-prev-translation-block))
+        ;; (menu-bar tty-menu-navigation-map tty-menu-prev-item)
+        ;; (widget widget-global-map previous-line))
+
+       ((abstract-previous "C-p" previous-line)
+
+        ("subr.el" esc-map forward-list)
+        (calendar-mode calendar-mode-map calendar-forward-week)
+        (comint-mode comint-repeat-map comint-next-prompt)
+        (company-mode (company-active-map company-select-next-or-abort)
+                      (company-search-map company-select-next-or-abort))
+        ;; (doc-view doc-view-mode-map doc-view-next-line-or-next-page)
+        (gnus gnus-summary-goto-map gnus-summary-prev-same-subject)
+        (kmacro kmacro-keymap kmacro-cycle-ring-next)
+        (org (org-agenda-keymap org-agenda-next-line)
+             (org-agenda-mode-map org-agenda-next-line)
+             (org-babel-map org-babel-next-src-block))
+        (outline (outline-mode-prefix-map outline-next-visible-heading)
+                 (outline-navigation-repeat-map outline-next-visible-heading))
+        (popup popup-menu-keymap popup-next)
+        (quail quail-simple-translation-keymap quail-other-command)
+        (quail quail-translation-keymap quail-prev-translation-block))))
+        ;; (menu-bar tty-menu-navigation-map tty-menu-prev-item)
+        ;; (widget widget-global-map next-line))))
+
 
 (provide 'user-keys-abstract)
 ;;; user-keys-abstract.el ends here

--- a/lisp/user-keys.el
+++ b/lisp/user-keys.el
@@ -258,7 +258,7 @@ that can be returned from `key-binding' and during
    (t
     (let* ((str-binding (format "%S" binding)))
       (if (> (length str-binding) 20)
-          (format "Bound to: %.20s..." s)
+          (format "Bound to: %.20s..." str-binding)
         (format "Bound to: %s" str-binding))))))
 
 (defun user-keys--major-mode-keymaps ()

--- a/test/user-keys-abstract-test.el
+++ b/test/user-keys-abstract-test.el
@@ -1,0 +1,200 @@
+;;; user-keys-abstract-test.el --- test your freaking package!  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022 Positron Solutions
+
+;; Author:  <author>
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy of
+;; this software and associated documentation files (the "Software"), to deal in
+;; the Software without restriction, including without limitation the rights to
+;; use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+;; the Software, and to permit persons to whom the Software is furnished to do so,
+;; subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+;; FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+;; COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+;; IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+;;; Commentary:
+
+;; Run the batch tests from root directory:
+;; nix shell .github#emacsGit --quick --script .github/run-shim.el -- test
+;; Test dependencies can be provided to the Emacsen declared inside the root
+;; flake.nix.
+
+;; For local development, dependencies should be installed by the user.  Tests
+;; can be run from one of the project files using the `erk-ert-project'
+;; command.
+
+;;; Code:
+
+(require 'ert)
+(require 'user-keys-abstract)
+
+(ert-deftest user-keys-abstract--expand-shadow-remaps-test ()
+  (should
+   (equal
+    ;; test with a single inline shadow-remap
+    (user-keys-abstract--expand-shadow-remaps
+     '((abstract-forward "C-n" forward-word)
+       (org org-mode-map org-forward-word)))
+
+    '((org
+       (define-key org-mode-map
+                   (kbd "C-n")
+                   nil t))
+      (org
+       (define-key org-mode-map
+                   (vector 'remap #'abstract-forward)
+                   #'org-forward-word)))))
+
+  (should
+   (equal
+    ;; test expansion of multiple shadow maps and inline.
+    ;; result should be flat (feature define-key) forms
+    (user-keys-abstract--expand-shadow-remaps
+     '((abstract-forward "C-n" forward-word)
+       (foo foo-mode-map foo-forward-word)
+       (bar (bar-one-mode-map bar-reverse)
+            (bar-two-mode-map bar-double))))
+    '((foo
+       (define-key foo-mode-map
+                   (kbd "C-n")
+                   nil t))
+      (foo
+       (define-key foo-mode-map
+                   (vector 'remap #'abstract-forward)
+                   #'foo-forward-word))
+      (bar
+       (define-key bar-one-mode-map
+                   (kbd "C-n")
+                   nil t))
+      (bar
+       (define-key bar-one-mode-map
+                   (vector 'remap #'abstract-forward)
+                   #'bar-reverse))
+      (bar
+       (define-key bar-two-mode-map
+                   (kbd "C-n")
+                   nil t))
+      (bar
+       (define-key bar-two-mode-map
+                   (vector 'remap #'abstract-forward)
+                   #'bar-double))))))
+
+(ert-deftest user-keys-abstract-define-remap-test ()
+  (should
+   (equal
+    (macroexpand
+     '(user-keys-abstract-define-remap
+       ((abstract-forward "C-n" forward-word)
+        (org org-mode-map org-forward-word))))
+    '(progn
+       (defun abstract-forward 'nil "Abstract command target.
+This is a global map abstract command."
+              (interactive)
+              (undefined))
+       (define-key global-map
+                   (kbd "C-n")
+                   #'abstract-forward)
+       (define-key global-map
+                   (vector 'remap #'abstract-forward)
+                   #'forward-word)
+       (eval-after-load org
+         (define-key org-mode-map
+                     (kbd "C-n")
+                     nil t)
+         (define-key org-mode-map
+                     (vector 'remap #'abstract-forward)
+                     #'org-forward-word)))))
+  (should
+   (equal
+    (macroexpand
+     `(user-keys-abstract-define-remap
+       ((abstract-forward "C-n" forward-word)
+        (bar (bar-one-mode-map bar-reverse)
+             (bar-two-mode-map bar-double)))))
+    '(progn
+       (defun abstract-forward 'nil "Abstract command target.
+This is a global map abstract command."
+              (interactive)
+              (undefined))
+       (define-key global-map
+                   (kbd "C-n")
+                   #'abstract-forward)
+       (define-key global-map
+                   (vector 'remap #'abstract-forward)
+                   #'forward-word)
+       (eval-after-load bar
+         (define-key bar-one-mode-map
+                     (kbd "C-n")
+                     nil t)
+         (define-key bar-one-mode-map
+                     (vector 'remap #'abstract-forward)
+                     #'bar-reverse)
+         (define-key bar-two-mode-map
+                     (kbd "C-n")
+                     nil t)
+         (define-key bar-two-mode-map
+                     (vector 'remap #'abstract-forward)
+                     #'bar-double)))))
+
+  (should
+   (equal
+    (macroexpand
+     `(user-keys-abstract-define-remap
+       ((abstract-quit "C-g" keyboard-quit)
+        (foo foo-mode-map foo-quit))
+       ((abstract-forward "C-n" forward-word)
+        (bar (bar-one-mode-map bar-reverse)
+             (bar-two-mode-map bar-double)))))
+    '(progn
+       (defun abstract-quit 'nil "Abstract command target.
+This is a global map abstract command."
+              (interactive)
+              (undefined))
+       (defun abstract-forward 'nil "Abstract command target.
+This is a global map abstract command."
+              (interactive)
+              (undefined))
+       (define-key global-map
+                   (kbd "C-g")
+                   #'abstract-quit)
+       (define-key global-map
+                   (vector 'remap #'abstract-quit)
+                   #'keyboard-quit)
+       (define-key global-map
+                   (kbd "C-n")
+                   #'abstract-forward)
+       (define-key global-map
+                   (vector 'remap #'abstract-forward)
+                   #'forward-word)
+       (eval-after-load foo
+         (define-key foo-mode-map
+                     (kbd "C-g")
+                     nil t)
+         (define-key foo-mode-map
+                     (vector 'remap #'abstract-quit)
+                     #'foo-quit))
+       (eval-after-load bar
+         (define-key bar-one-mode-map
+                     (kbd "C-n")
+                     nil t)
+         (define-key bar-one-mode-map
+                     (vector 'remap #'abstract-forward)
+                     #'bar-reverse)
+         (define-key bar-two-mode-map
+                     (kbd "C-n")
+                     nil t)
+         (define-key bar-two-mode-map
+                     (vector 'remap #'abstract-forward)
+                     #'bar-double))))))
+
+(provide 'user-keys-abstract-test)
+;;; user-keys-abstract-test.el ends here.

--- a/test/user-keys-abstract-test.el
+++ b/test/user-keys-abstract-test.el
@@ -93,74 +93,73 @@
    (equal
     (macroexpand
      '(user-keys-abstract-define-remap
-       ((abstract-forward "C-n" forward-word)
+       ((abstract-forward "C-q" forward-word)
         (org org-mode-map org-forward-word))))
     '(progn
-       (defun abstract-forward 'nil "Abstract command target.
-This is a global map abstract command."
+       (defun abstract-forward 'nil "Abstract command target.\nThis is a global map abstract command."
               (interactive)
               (undefined))
        (define-key global-map
-                   (kbd "C-n")
+                   (kbd "C-q")
                    #'abstract-forward)
        (define-key global-map
                    (vector 'remap #'abstract-forward)
                    #'forward-word)
-       (eval-after-load org
-         (define-key org-mode-map
-                     (kbd "C-n")
-                     nil t)
-         (define-key org-mode-map
-                     (vector 'remap #'abstract-forward)
-                     #'org-forward-word)))))
-  (should
-   (equal
-    (macroexpand
-     `(user-keys-abstract-define-remap
-       ((abstract-forward "C-n" forward-word)
-        (bar (bar-one-mode-map bar-reverse)
-             (bar-two-mode-map bar-double)))))
-    '(progn
-       (defun abstract-forward 'nil "Abstract command target.
-This is a global map abstract command."
-              (interactive)
-              (undefined))
-       (define-key global-map
-                   (kbd "C-n")
-                   #'abstract-forward)
-       (define-key global-map
-                   (vector 'remap #'abstract-forward)
-                   #'forward-word)
-       (eval-after-load bar
-         (define-key bar-one-mode-map
-                     (kbd "C-n")
-                     nil t)
-         (define-key bar-one-mode-map
-                     (vector 'remap #'abstract-forward)
-                     #'bar-reverse)
-         (define-key bar-two-mode-map
-                     (kbd "C-n")
-                     nil t)
-         (define-key bar-two-mode-map
-                     (vector 'remap #'abstract-forward)
-                     #'bar-double)))))
+       (eval-after-load 'org
+         (progn
+           (define-key org-mode-map
+                       (kbd "C-q")
+                       nil t)
+           (define-key org-mode-map
+                       (vector 'remap #'abstract-forward)
+                       #'org-forward-word))))))
 
   (should
    (equal
     (macroexpand
-     `(user-keys-abstract-define-remap
+     '(user-keys-abstract-define-remap
+       ((abstract-forward "C-n" forward-word)
+        (bar (bar-one-mode-map bar-reverse)
+             (bar-two-mode-map bar-double)))))
+    '(progn
+       (defun abstract-forward 'nil "Abstract command target.\nThis is a global map abstract command."
+              (interactive)
+              (undefined))
+       (define-key global-map
+                   (kbd "C-n")
+                   #'abstract-forward)
+       (define-key global-map
+                   (vector 'remap #'abstract-forward)
+                   #'forward-word)
+       (eval-after-load 'bar
+         (progn
+           (define-key bar-one-mode-map
+                       (kbd "C-n")
+                       nil t)
+           (define-key bar-one-mode-map
+                       (vector 'remap #'abstract-forward)
+                       #'bar-reverse)
+           (define-key bar-two-mode-map
+                       (kbd "C-n")
+                       nil t)
+           (define-key bar-two-mode-map
+                       (vector 'remap #'abstract-forward)
+                       #'bar-double))))))
+
+  (should
+   (equal
+    (macroexpand
+     '(user-keys-abstract-define-remap
        ((abstract-quit "C-g" keyboard-quit)
         (foo foo-mode-map foo-quit))
        ((abstract-forward "C-n" forward-word)
         (bar (bar-one-mode-map bar-reverse)
              (bar-two-mode-map bar-double)))))
     '(progn
-       (defun abstract-quit 'nil "Abstract command target.
-This is a global map abstract command."
+       (defun abstract-quit 'nil "Abstract command target.\nThis is a global map abstract command."
               (interactive)
               (undefined))
-       (defun abstract-forward 'nil "Abstract command target.
-This is a global map abstract command."
+       (defun abstract-forward 'nil "Abstract command target.\nThis is a global map abstract command."
               (interactive)
               (undefined))
        (define-key global-map
@@ -175,26 +174,28 @@ This is a global map abstract command."
        (define-key global-map
                    (vector 'remap #'abstract-forward)
                    #'forward-word)
-       (eval-after-load foo
-         (define-key foo-mode-map
-                     (kbd "C-g")
-                     nil t)
-         (define-key foo-mode-map
-                     (vector 'remap #'abstract-quit)
-                     #'foo-quit))
-       (eval-after-load bar
-         (define-key bar-one-mode-map
-                     (kbd "C-n")
-                     nil t)
-         (define-key bar-one-mode-map
-                     (vector 'remap #'abstract-forward)
-                     #'bar-reverse)
-         (define-key bar-two-mode-map
-                     (kbd "C-n")
-                     nil t)
-         (define-key bar-two-mode-map
-                     (vector 'remap #'abstract-forward)
-                     #'bar-double))))))
+       (eval-after-load 'foo
+         (progn
+           (define-key foo-mode-map
+                       (kbd "C-g")
+                       nil t)
+           (define-key foo-mode-map
+                       (vector 'remap #'abstract-quit)
+                       #'foo-quit)))
+       (eval-after-load 'bar
+         (progn
+           (define-key bar-one-mode-map
+                       (kbd "C-n")
+                       nil t)
+           (define-key bar-one-mode-map
+                       (vector 'remap #'abstract-forward)
+                       #'bar-reverse)
+           (define-key bar-two-mode-map
+                       (kbd "C-n")
+                       nil t)
+           (define-key bar-two-mode-map
+                       (vector 'remap #'abstract-forward)
+                       #'bar-double)))))))
 
 (provide 'user-keys-abstract-test)
 ;;; user-keys-abstract-test.el ends here.


### PR DESCRIPTION
Oh hey, let's see if CI still works.

This PR introduces a solution for kludging abstract keys on top of regular Emacs

Basically, instead of ad-hoc conventions where everyone shadows the key that they think a command should be bound to, they can use a remap to instead change what a particular command does.  This respects precedence, so higher maps still shadow lower ones.

The solution is not necessarily meant to work long term or at scale, but to demonstrate the idea of using mass remap (which might need some implementation improvements) in order to tame the wild wild west of ad-hoc key binding conventions and **give control back to the user**